### PR TITLE
Allow redirects while checking images.

### DIFF
--- a/check_images.py
+++ b/check_images.py
@@ -12,7 +12,7 @@ def check_images():
                 continue
             url = line.split()[1]
             try:
-                req = requests.head(url, verify=False, timeout = 8)
+                req = requests.head(url, verify=False, timeout = 8, allow_redirects=True)
                 print(line.strip())
                 if req.status_code == 200 and 'Content-Type' in req.headers and 'image/' in req.headers['Content-Type']:
                     print(' OK')


### PR DESCRIPTION
By default requests library [does not follow](http://docs.python-requests.org/en/latest/user/quickstart/#redirection-and-history) redirects for HEAD requests. This can cause false negative check results.
